### PR TITLE
use event.currentTarget instead of event.target

### DIFF
--- a/resources/ui/src/App/Components/Pagination/index.js
+++ b/resources/ui/src/App/Components/Pagination/index.js
@@ -111,7 +111,7 @@ export default {
       this.$emit('page-updated', pageNumber);
     },
     updatePerPage(event) {
-      this.$emit('per-page-updated', event.target.value);
+      this.$emit('per-page-updated', event.currentTarget.value);
       event.preventDefault();
     },
     movePrevious() {

--- a/resources/ui/src/Site/replies.js
+++ b/resources/ui/src/Site/replies.js
@@ -172,7 +172,7 @@
 
           _this.data.ReplyForm = _this.getReplyForm();
 
-          let replyingTo = event.target.getAttribute('data-meerkat-reply-to');
+          let replyingTo = event.currentTarget.getAttribute('data-meerkat-reply-to');
 
           _this.data.ReplyForm.appendChild(_this.makeReplyInput(replyingTo));
           _this.data.ReplyForm.addEventListener('submit', _this.data.Extend.submit, false);
@@ -225,7 +225,7 @@
       });
     },
     replyHandler: function (event) {
-      let meerkatForm = MeerkatForms.findClosest(event.target, '[data-meerkat-form]');
+      let meerkatForm = MeerkatForms.findClosest(event.currentTarget, '[data-meerkat-form]');
 
       if (typeof meerkatForm !== 'undefined' && meerkatForm !== null) {
 


### PR DESCRIPTION
I just went down a nasty debugging route because replies weren't working. I found out, that the reply-to id (hidden input `ids`) wasn't passed to the cloned reply form. The reason is that my <button> element has children and `event.target` returns the exact clicked element while `event.currentTarget` returns the element the listener is bound on.

This pull request changes all occurences of `event.target` to `event.currentTarget`.